### PR TITLE
add claude config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ gitconfig_local_overrides
 
 # local zshrc overrides (machine-specific, not committed)
 zshrc_local_overrides
+
+# only check in specific claude config files
+claude/*
+!claude/CLAUDE.md
+!claude/settings.json

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -8,3 +8,6 @@
 ## Code style
 - No comments unless the why is genuinely non-obvious.
 - No docstrings.
+
+## Git
+- Do not include Claude as a co-author in commits.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,10 @@
+# Global Claude Instructions
+
+## Communication
+- Be concise. Skip trailing summaries of what you just did.
+- No emojis.
+- No unsolicited refactoring, cleanup, or abstractions beyond what the task requires.
+
+## Code style
+- No comments unless the why is genuinely non-obvious.
+- No docstrings.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true
+  }
+}

--- a/make.sh
+++ b/make.sh
@@ -16,4 +16,3 @@ do
 	echo "Creating symlink to $file in home directory"
 	ln -s $dir/$file ~/.$file
 done
-


### PR DESCRIPTION
## Summary
- Adds `claude/` directory with a minimal global `CLAUDE.md` and `settings.json` (shared LSP plugins)
- Updates `.gitignore` to whitelist only `CLAUDE.md` and `settings.json` from `claude/`; runtime files written by Claude Code are ignored
- Machine-specific plugins go in `~/.claude/settings.local.json` (not checked in)

## Test plan
- [ ] Run `make.sh` on a fresh machine and verify `~/.claude` is symlinked to `claude/`
- [ ] Verify `CLAUDE.md` and `settings.json` are picked up by Claude Code
- [ ] Verify ephemeral files written to `~/.claude` do not show as untracked in git