### PR TITLE
Add worktree workflow and tmuxinator default layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ config/kitty/*
 config/tmux/*
 !config/tmux/tmux.conf
 
+# allow tmuxinator default template only
+!config/tmuxinator
+config/tmuxinator/*
+!config/tmuxinator/default.yml
+
 # disallow lein repl history
 lein/repl-history
 
@@ -40,3 +45,8 @@ zshrc_local_overrides
 claude/*
 !claude/CLAUDE.md
 !claude/settings.json
+!claude/keybindings.json
+!claude/commands
+claude/commands/*
+!claude/commands/new-worktree.md
+!claude/commands/close-worktree.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Dotfiles
+
+## Installation
+
+`make.sh` symlinks each top-level file/dir in this repo to its `~/.<name>` counterpart. Notable result: `~/.claude` is a symlink to `claude/` in this repo, so edits to `claude/` take effect immediately without reinstalling.
+
+## Adding files to tracked directories
+
+Directories like `claude/`, `config/`, etc. are gitignored by default with explicit allowlist exceptions. Before adding a new file inside one of these directories, add a `!path/to/file` exception to `.gitignore` or it won't be tracked.
+
+## Custom Claude commands
+
+Two global commands live in `claude/commands/` and are available in any repo:
+
+- `/new-worktree <branch>` — pulls master, creates a git worktree at `$DEVHOME/worktrees/<repo>/<branch>`, and starts a detached tmuxinator session named after the branch
+- `/close-worktree <branch>` — checks merge status (prompts if unmerged), removes the worktree, deletes the branch, and kills the tmux session
+
+## tmuxinator default layout
+
+`mux start default` opens three windows: `nvim`, `claude`, `zsh`, rooted at the current directory. Override with env vars:
+
+```
+PROJECT_ROOT=<path> PROJECT_NAME=<name> mux start default --no-attach
+```

--- a/README.md
+++ b/README.md
@@ -34,4 +34,9 @@ brew install jenv nodenv pyenv rbenv
 
 # tmux additional steps
 - Install the [tmux plugin manager](https://github.com/tmux-plugins/tpm)
-- Use [tmuxinator](https://github.com/tmuxinator/tmuxinator) for workspace management
+- Install [tmuxinator](https://github.com/tmuxinator/tmuxinator) for workspace management:
+```zsh
+brew install tmuxinator
+```
+- The default layout (`mux start default`) opens nvim, claude, and a terminal in the current directory
+- To override per-project, run `mux new <project-name>` or place `.tmuxinator.yml` in the project root and run `mux local`

--- a/claude/commands/close-worktree.md
+++ b/claude/commands/close-worktree.md
@@ -1,0 +1,33 @@
+Close the worktree, tmux session, and branch for `$ARGUMENTS` by following these steps in order:
+
+1. Get the repo name:
+   ```
+   basename $(git rev-parse --show-toplevel)
+   ```
+
+2. Detect the default branch:
+   ```
+   git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+   ```
+
+3. Check if the branch is merged into the default branch:
+   ```
+   git branch --merged <default-branch> | grep -w $ARGUMENTS
+   ```
+   If the branch is NOT merged, stop and ask the user: "Branch `$ARGUMENTS` has not been merged into `<default-branch>`. Continue closing and deleting it?"
+   Do not proceed until the user confirms.
+
+4. Remove the worktree (force in case of untracked files):
+   ```
+   git worktree remove --force ${DEVHOME:-$HOME/Dev}/worktrees/<reponame>/$ARGUMENTS
+   ```
+
+5. Delete the branch:
+   - If merged: `git branch -d $ARGUMENTS`
+   - If unmerged but user confirmed: `git branch -D $ARGUMENTS`
+
+6. Kill the tmux session:
+   ```
+   tmux kill-session -t $ARGUMENTS
+   ```
+   If the session doesn't exist, continue without error.

--- a/claude/commands/new-worktree.md
+++ b/claude/commands/new-worktree.md
@@ -1,0 +1,33 @@
+Create a new git worktree for branch `$ARGUMENTS` by running these steps in order:
+
+1. Detect the default branch:
+   ```
+   git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+   ```
+
+2. Switch to the default branch and pull latest:
+   ```
+   git checkout <default-branch> && git pull
+   ```
+
+3. Get the repo name:
+   ```
+   basename $(git rev-parse --show-toplevel)
+   ```
+
+4. Set the worktree path:
+   ```
+   ${DEVHOME:-$HOME/Dev}/worktrees/<reponame>/$ARGUMENTS
+   ```
+
+5. Create the directory and worktree:
+   ```
+   mkdir -p <worktree-path>
+   git worktree add <worktree-path> -b $ARGUMENTS <default-branch>
+   ```
+   If the branch already exists locally, omit `-b`.
+
+6. Start a new tmuxinator session rooted at the worktree without attaching (leaves the current session unchanged):
+   ```
+   PROJECT_ROOT=<worktree-path> PROJECT_NAME=$ARGUMENTS mux start default --no-attach
+   ```

--- a/claude/keybindings.json
+++ b/claude/keybindings.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": []
+}

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -3,11 +3,14 @@ unbind C-b
 set-option -g prefix C-a
 bind-key C-a send-prefix
 
+# open new windows and split panes in the current directory
+bind c new-window -c "#{pane_current_path}"
+
 # split panes using | and -
 unbind '"'
 unbind %
-bind | split-window -h
-bind - split-window -v
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
 
 # navigate windows forward w space and back with backspace
 bind-key space next-window

--- a/config/tmuxinator/default.yml
+++ b/config/tmuxinator/default.yml
@@ -1,0 +1,17 @@
+# Default "working on a repo" layout.
+# Run from within a project directory: mux start default
+# The session name and root default to the current directory.
+#
+# Override PROJECT_ROOT or PROJECT_NAME to set them explicitly:
+#   PROJECT_ROOT=~/Dev/myproject mux start default
+#
+# Per-project override: create ~/.config/tmuxinator/<project>.yml
+# or place .tmuxinator.yml in the project root and run: mux local
+
+name: <%= ENV['PROJECT_NAME'] || File.basename(Dir.pwd) %>
+root: <%= ENV['PROJECT_ROOT'] || Dir.pwd %>
+
+windows:
+  - editor: nvim
+  - ai: claude
+  - zsh:

--- a/make.sh
+++ b/make.sh
@@ -3,7 +3,10 @@
 # Creates symlinks from ~ to any desired dotfiles
 dir=`pwd`
 olddir=~/dotfiles_backup
-files=`ls | grep "[^make\.sh|README\.md]"`
+# files in this repo that should NOT be symlinked into ~
+ignore=(make.sh README.md CLAUDE.md)
+ignore_pattern=$(IFS='|'; echo "^(${ignore[*]})$")
+files=`ls | grep -Ev "$ignore_pattern"`
 
 echo "Creating $olddir for backup of any existing dotfiles in ~"
 mkdir -p $olddir

--- a/zshrc
+++ b/zshrc
@@ -126,6 +126,11 @@ plugins=(git tmux vi-mode)
 
 source $ZSH/oh-my-zsh.sh
 
+# The omz tmux plugin aliases `tmux` to `_zsh_tmux_plugin_run`, but Claude Code's
+# shell snapshot captures aliases without the referenced function, breaking `tmux`.
+# Unaliasing here lets `tmux` resolve to the real binary while keeping autostart.
+unalias tmux 2>/dev/null || true
+
 # User configuration
 
 # export MANPATH="/usr/local/man:$MANPATH"


### PR DESCRIPTION
## Summary
- Adds `/new-worktree` and `/close-worktree` Claude commands for managing git worktrees paired with tmux sessions (stored under `$DEVHOME/worktrees/<repo>/<branch>`)
- Adds tmuxinator default layout opening nvim, claude, and zsh in the project root
- Configures tmux to open new windows and pane splits in the current directory
- Fixes `make.sh` ignore pattern and adds `CLAUDE.md` to the ignore list
- Adds project `CLAUDE.md` documenting repo structure and custom commands
- Unaliases `tmux` in zshrc to fix a Claude Code shell snapshot incompatibility with the omz tmux plugin

## Test plan
- [ ] `/new-worktree <branch>` creates worktree at `$DEVHOME/worktrees/<repo>/<branch>` and starts detached tmux session
- [ ] `/close-worktree <branch>` prompts if unmerged, then removes worktree, deletes branch, kills session
- [ ] `mux start default` opens nvim, claude, zsh in current directory
- [ ] `ctrl+a c` opens new window in current directory
- [ ] `ctrl+a |` and `ctrl+a -` split in current directory
- [ ] `make.sh` does not symlink `CLAUDE.md` or `README.md`